### PR TITLE
Remove writing of comments in PFM files

### DIFF
--- a/src/pnmio.c
+++ b/src/pnmio.c
@@ -609,8 +609,6 @@ void write_pfm_file(FILE *f, float *img_out, char *img_out_fname,
   x_scaled_size = x_size;
   y_scaled_size = y_size;
 
-  /* Write a comment containing the file name. */
-  fprintf(f, "# %s\n", img_out_fname);
   /* Write the magic number string. */
   if (img_type == RGB_TYPE) {
     fprintf(f, "PF\n");


### PR DESCRIPTION
The 32bit variant of PBM does not have comments in it:

<http://netpbm.sourceforge.net/doc/pfm.html>

<http://www.pauldebevec.com/Research/HDR/PFM/>

<https://en.wikipedia.org/wiki/Netpbm#32-bit_extensions>

Writing a comment into the header breaks file readers that adhere to the defintion of the format.